### PR TITLE
Fix evp 1d masking issues

### DIFF
--- a/cicecore/cicedynB/general/ice_init.F90
+++ b/cicecore/cicedynB/general/ice_init.F90
@@ -1298,14 +1298,14 @@
                write(nu_diag,1010) ' revised_evp      = ', revised_evp,trim(tmpstr2)
        
                if (evp_algorithm == 'standard_2d') then
-                  tmpstr2 = ' : standard EVP solver'
+                  tmpstr2 = ' : standard 2d EVP solver'
                elseif (evp_algorithm == 'shared_mem_1d') then
-                  tmpstr2 = ' : vectorized EVP solver'
+                  tmpstr2 = ' : vectorized 1d EVP solver'
                   pgl_global_ext = .true.
                else
                   tmpstr2 = ' : unknown value'
                endif
-               write(nu_diag,1030) ' evp_algorithm    = ', trim(tmpstr2)
+               write(nu_diag,1031) ' evp_algorithm    = ', trim(evp_algorithm),trim(tmpstr2)
                write(nu_diag,1020) ' ndtd             = ', ndtd, ' : number of dynamics/advection/ridging/steps per thermo timestep'
                write(nu_diag,1020) ' ndte             = ', ndte, ' : number of EVP or EAP subcycles'
             endif


### PR DESCRIPTION

## PR checklist
- [X] Short (1 sentence) summary of your PR: 
    Fix evp 1d masking issues, seems to be final fix to get 1d debug results bit-for-bit with 2d.
- [X] Developer(s): 
    apcraig
- [ ] Suggest PR reviewers from list in the column to the right.
- [X] Please copy the PR test results link or provide a summary of testing completed below.
    Full test suites run on cheyenne with intel, pgi, and gnu.  Tested 1d evp debug vs 2d evp debug.  Also tested standard test suite vs baseline.  All results are as expected.  alt04 results are different, 1x1 and 2x2 still broken, unit tests different, some tests time out in debug mode due to slower run times.  There were partly run manually, but mostly just skipped.  We have a large sample of positive results, so we shoudl be OK.  https://github.com/CICE-Consortium/Test-Results/wiki/cice_by_hash_forks#126245535038576bb68746004754915fe96ee06c
- How much do the PR code changes differ from the unmodified code? 
    - [X] bit for bit, except 1d evp which has a bug fix
    - [ ] different at roundoff level
    - [ ] more substantial
- Does this PR create or have dependencies on Icepack or any other models?
    - [ ] Yes
    - [X] No
- Does this PR add any new test cases?
    - [ ] Yes
    - [X] No
- Is the documentation being updated? ("Documentation" includes information on the wiki or in the .rst files from doc/source/, which are used to create the online technical docs at https://readthedocs.org/projects/cice-consortium-cice/. A test build of the technical docs will be performed as part of the PR testing.)
    - [ ] Yes
    - [X] No, does the documentation need to be updated at a later time?
        - [ ] Yes
        - [X] No 
- [ ] Please provide any additional information or relevant details below:

- There are relatively rare cases/gridcells where stress (tmask) and stepu (umask) are advanced
without the other.  The 1d evp implementation was not addressing this issue, so skiptcell was added
to the 1d evp (similar to skipucell) to mask out cells separately for stress and stepu.  This
fixed a few non bit-for-bit cases in testing.

- Cleaned up some indentation and other minor issues in 1d evp.

- Updated the evp_algorithm log output in ice_init.

